### PR TITLE
make the repo to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,19 @@ Puppet Mocker & Starter for Wechaty, it is very useful when you:
 
 Then `PuppetMock` will helps you a lot.
 
+## RUN
+```
+npm install
+npm run start
+```
+
 ## USAGE
 
 ```ts
-import { MemoryCard } from 'memory-card'
+import { Wechaty    } from 'wechaty'
 import { PuppetMock } from 'wechaty-puppet-mock'
 
-const puppet  = new PuppetMock({ memory: new MemoryCard() })
+const puppet  = new PuppetMock()
 const wechaty = new Wechaty({ puppet })
 ```
 

--- a/example/starter-bot.ts
+++ b/example/starter-bot.ts
@@ -1,0 +1,16 @@
+import { Wechaty    } from 'wechaty'
+import { PuppetMock } from '../src/puppet-mock'
+
+const puppet  = new PuppetMock()
+const bot = new Wechaty({ puppet })
+
+bot
+.on('scan', (qrcode, status) => console.log('Scan QR Code to login'))
+.on('login', (user) => console.log(`User ${user} logined`))
+.on('message', (message) => console.log(`Message: ${message}`))
+.start()
+.catch(async (e) => {
+  console.error('Bot start() fail:', e)
+  await bot.stop()
+  process.exit(-1)
+})

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "wechaty": ">=0.17.46"
   },
   "scripts": {
+    "start": "ts-node example/starter-bot.ts",
     "clean": "shx rm -fr dist/*",
     "dist": "npm run clean && tsc",
     "pack": "npm pack",
@@ -60,8 +61,7 @@
     "ts-node": "^7.0.0",
     "tslint": "^5.10.0",
     "tslint-config-standard": "^7.1.0",
-    "typescript": "^2.9.2",
-    "wechaty-puppet": "^0.15.3"
+    "typescript": "^2.9.2"
   },
   "git": {
     "scripts": {
@@ -70,8 +70,7 @@
   },
   "peerDependencies": {
     "file-box": "^0.8.22",
-    "memory-card": "^0.4.10",
-    "wechaty-puppet": "^0.15.3"
+    "memory-card": "^0.4.10"
   },
   "dependencies": {
     "brolog": "^1.6.5",
@@ -80,6 +79,8 @@
     "qr-image": "^3.2.0",
     "quick-lru": "^1.1.0",
     "state-switch": "^0.6.2",
-    "watchdog": "^0.8.10"
+    "watchdog": "^0.8.10",
+    "wechaty": "^0.22.4",
+    "wechaty-puppet": "^0.14.1"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "trailing-comma": true,
     "import-spacing": false,
     "no-multi-spaces": false,
+    "no-console": false,
     "typedef-whitespace": false
   }
 }


### PR DESCRIPTION
In order to let more developers create puppet themselves, I suggest them to run mock bot first.

But I found this repo cannot run because a lot of packages is out of date and README lack a lot of intro of how to run the bot.

Also, when I npm install this package in another repo, it cannot run as expected, see #14 

So I add did 3 kinds of things on this pr:
1. update the related packages
2. add intro in README
3. add a demo to run the mock bot.

After this pr, it can run as expect:
```shell
➜  wechaty-puppet-mock git:(master) npm run start

> wechaty-puppet-mock@0.15.2 start /Users/jiaruili/git/rui/wechaty-puppet-mock
> ts-node example/starter-bot.ts

21:58:12 INFO Wechaty <Puppet#0<PuppetMock>()> start() v0.22.4 is starting...
Scan QR Code to login
User Contact<mock-name> logined
Message: Message#Text(🗣Contact<mock-name>👤Contact<mock-name>)<mock text>
Message: Message#Text(🗣Contact<mock-name>👤Contact<mock-name>)<mock text>
Message: Message#Text(🗣Contact<mock-name>👤Contact<mock-name>)<mock text>
Message: Message#Text(🗣Contact<mock-name>👤Contact<mock-name>)<mock text>
Message: Message#Text(🗣Contact<mock-name>👤Contact<mock-name>)<mock text>
Message: Message#Text(🗣Contact<mock-name>👤Contact<mock-name>)<mock text>
```